### PR TITLE
Allow relative urls in manifest in WebPackageResolver

### DIFF
--- a/Onova/Services/WebPackageResolver.cs
+++ b/Onova/Services/WebPackageResolver.cs
@@ -58,7 +58,7 @@ namespace Onova.Services
                     continue;
 
                 if (url.StartsWith("./"))
-                    url = url.Replace("./", GetUrlDirectory(_manifestUrl));
+                    url = new Uri(new Uri(_manifestUrl), url).ToString();
 
                 // Add to dictionary
                 map[version] = url;
@@ -66,13 +66,7 @@ namespace Onova.Services
 
             return map;
         }
-
-        private static string GetUrlDirectory(string url)
-        {
-            int lastSlash = url.LastIndexOf('/');
-            return url.Substring(0, lastSlash + 1);
-        }
-
+        
         /// <inheritdoc />
         public async Task<IReadOnlyList<Version>> GetVersionsAsync()
         {

--- a/Onova/Services/WebPackageResolver.cs
+++ b/Onova/Services/WebPackageResolver.cs
@@ -66,7 +66,7 @@ namespace Onova.Services
 
             return map;
         }
-        
+
         /// <inheritdoc />
         public async Task<IReadOnlyList<Version>> GetVersionsAsync()
         {

--- a/Onova/Services/WebPackageResolver.cs
+++ b/Onova/Services/WebPackageResolver.cs
@@ -57,8 +57,8 @@ namespace Onova.Services
                 if (!Version.TryParse(versionText, out var version))
                     continue;
 
-                if (url.StartsWith("./"))
-                    url = new Uri(new Uri(_manifestUrl), url).ToString();
+                // Convert to Uri and back to account for relative paths, etc
+                url = new Uri(new Uri(_manifestUrl), url).ToString();
 
                 // Add to dictionary
                 map[version] = url;

--- a/Onova/Services/WebPackageResolver.cs
+++ b/Onova/Services/WebPackageResolver.cs
@@ -57,11 +57,20 @@ namespace Onova.Services
                 if (!Version.TryParse(versionText, out var version))
                     continue;
 
+                if (url.StartsWith("./"))
+                    url = url.Replace("./", GetUrlDirectory(_manifestUrl));
+
                 // Add to dictionary
                 map[version] = url;
             }
 
             return map;
+        }
+
+        private static string GetUrlDirectory(string url)
+        {
+            int lastSlash = url.LastIndexOf('/');
+            return url.Substring(0, lastSlash + 1);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
If there's a line like `1.2.3 ./build.zip` in `http://www.example.com/manifest.txt`, the archive URL will be set to `http://www.example.com/build.zip`.