### PR TITLE
Fix .NET Core 3.X running WPF/WinForms

### DIFF
--- a/Onova.Updater/Internal/DirectoryEx.cs
+++ b/Onova.Updater/Internal/DirectoryEx.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Threading;
 
 namespace Onova.Updater.Internal
 {
@@ -17,6 +18,11 @@ namespace Onova.Updater.Internal
                 // Get destination file path
                 var destFileName = Path.GetFileName(sourceFilePath);
                 var destFilePath = Path.Combine(destDirPath, destFileName);
+
+                Program.WriteLog($"Waiting for file to be writable... {destFilePath}");
+                while (File.Exists(destFilePath) && !FileEx.CheckWriteAccess(destFilePath))
+                    Thread.Sleep(100);
+
                 File.Copy(sourceFilePath, destFilePath, overwrite);
             }
 

--- a/Onova.Updater/Program.cs
+++ b/Onova.Updater/Program.cs
@@ -18,10 +18,36 @@ namespace Onova.Updater
         private static string LogFilePath => Path.Combine(AssemblyDirPath, "Log.txt");
         private static Version Version => Assembly.GetExecutingAssembly().GetName().Version;
 
-        private static void WriteLog(string value)
+        public static void WriteLog(string value)
         {
             var date = DateTimeOffset.Now;
             _log.WriteLine($"{date:dd-MMM-yyyy HH:mm:ss.fff}> {value}");
+        }
+
+        public static void Main(string[] args)
+        {
+            // Write log
+            using (_log = File.CreateText(LogFilePath))
+            {
+                // Launch info
+                WriteLog($"Onova Updater v{Version} started with args: [{args.JoinToString(", ")}].");
+
+                try
+                {
+                    // Extract arguments
+                    var updateeFilePath = args[0];
+                    var packageContentDirPath = args[1];
+                    var restartUpdatee = bool.Parse(args[2]);
+
+                    // Execute update
+                    Update(updateeFilePath, packageContentDirPath, restartUpdatee);
+                    WriteLog("Update completed successfully.");
+                }
+                catch (Exception ex)
+                {
+                    WriteLog(ex.ToString());
+                }
+            }
         }
 
         private static void Update(string updateeFilePath, string packageContentDirPath, bool restartUpdatee)
@@ -53,32 +79,6 @@ namespace Onova.Updater
             // Delete package content directory
             WriteLog("Deleting package contents from storage...");
             Directory.Delete(packageContentDirPath, true);
-        }
-
-        public static void Main(string[] args)
-        {
-            // Write log
-            using (_log = File.CreateText(LogFilePath))
-            {
-                // Launch info
-                WriteLog($"Onova Updater v{Version} started with args: [{args.JoinToString(", ")}].");
-
-                try
-                {
-                    // Extract arguments
-                    var updateeFilePath = args[0];
-                    var packageContentDirPath = args[1];
-                    var restartUpdatee = bool.Parse(args[2]);
-
-                    // Execute update
-                    Update(updateeFilePath, packageContentDirPath, restartUpdatee);
-                    WriteLog("Update completed successfully.");
-                }
-                catch (Exception ex)
-                {
-                    WriteLog(ex.ToString());
-                }
-            }
         }
     }
 }

--- a/Onova.Updater/Program.cs
+++ b/Onova.Updater/Program.cs
@@ -41,7 +41,12 @@ namespace Onova.Updater
             {
                 WriteLog("Restarting updatee...");
 
-                using (var restartedUpdateeProcess = Process.Start(updateeFilePath))
+                ProcessStartInfo start = new ProcessStartInfo();
+                start.FileName = updateeFilePath; // Specify exe name.
+                start.UseShellExecute = false;
+                start.WorkingDirectory = Path.GetDirectoryName(updateeFilePath);
+
+                using (var restartedUpdateeProcess = Process.Start(start))
                     WriteLog($"Restarted as pid:{restartedUpdateeProcess?.Id}.");
             }
 

--- a/Onova/Models/AssemblyMetadata.cs
+++ b/Onova/Models/AssemblyMetadata.cs
@@ -63,7 +63,8 @@ namespace Onova.Models
         public static AssemblyMetadata FromEntryAssembly()
         {
             var entryAssembly = Assembly.GetEntryAssembly();
-            string framework = entryAssembly.GetCustomAttribute<TargetFrameworkAttribute>().FrameworkName;
+
+            string framework  = entryAssembly.GetCustomAttribute<TargetFrameworkAttribute>().FrameworkName;
             if (framework.StartsWith(".NETCoreApp"))
             {
                 var name        = entryAssembly.GetName().Name;
@@ -74,7 +75,7 @@ namespace Onova.Models
                 {
                     filePath = Path.ChangeExtension(filePath, ".exe");
                     if (!File.Exists(filePath))
-                        throw new FileNotFoundException($"Currently executing assembly was DLL, so assumed WPF/WinForms .NET Core, but exe with same name {Path.GetFileName(filePath)} does not exist.");
+                        throw new FileNotFoundException($"Entry assembly was .NET Core DLL. Defaulted to assume assumed WPF/WinForms application, but exe with same name {Path.GetFileName(filePath)} does not exist. If the source is a .NET Core console application, please refer to the readme.");
                 }
 
                 return new AssemblyMetadata(name, version, filePath);

--- a/Readme.md
+++ b/Readme.md
@@ -120,6 +120,32 @@ if (result.CanUpdate)
     Environment.Exit(0);
 }
 ```
+### Handling .NET Core Applications
+If your application is a .NET Core application and the start-up file is a DLL as opposed to an .exe, you can work around this by passing a custom instance of `AssemblyMetadata` to `UpdateManager`. 
+
+Assuming that your project is called `MyProject` and compiles to `MyProject.dll`.
+
+##### A. Make a batch script (`MyProject.bat`)
+```batch
+dotnet MyProject.dll
+```
+
+Include it in your project as `Content` set to `Copy Always`, it should copy to your output directory.
+
+
+##### B. Pass custom AssemblyMetadata to UpdateManager.
+```csharp
+var entryAssembly = Assembly.GetEntryAssembly();
+var name        = entryAssembly.GetName().Name;
+var version     = entryAssembly.GetName().Version;
+var filePath    = Path.GetDirectoryName(entryAssembly.Location) + "\\MyProject.bat";
+
+var metadata = new AssemblyMetadata(name, version, filePath);
+using (var manager = new UpdateManager(metadata, ...))
+...
+```
+
+When Onova's updater will try to restart your application, it will now run the batch file instead.
 
 ### Handling updates with multiple running instances of the application
 
@@ -131,6 +157,7 @@ In order to correctly handle cases where multiple instances of the application m
 - `UpdaterAlreadyLaunchedException` - thrown by `PrepareUpdateAsync` and `LaunchUpdater` when an updater executable has already been launched, either by this instance of `UpdateManager` or another instance that has released the lock file.
 
 The updater will wait until all instances of the application have exited before applying an update, regardless of which instance launched it.
+
 
 ## Libraries used
 


### PR DESCRIPTION
## Problem
In .NET Core 3.X WPF/WinForms applications the entry assembly is not the file used to launch the program. This causes `Onova.Updater` will try to launch a DLL on restart.

## Issue (Behind the Scenes)
When running a .NET Core 3.X WPF or WinForms application, the actual executing code of the main module lies in a different assembly than the file used to start up the program.

i.e. For project `MyProject`, .NET Core 3.X will export:
- MyProject.dll
- MyProject.exe

In this case, despite `MyProject.exe` being used to start the application, `MyProject.dll` is actually the assembly containing all of the executing code. `MyProject.exe` is only a bootstrapper to launch the MyProject DLL with .NET Core, which is considered the Entry Assembly (Assembly.GetEntryAssembly()).

## Pull Request

The following commit modifies the extension when creating `AssemblyMetadata` from the entry assembly. If the current runtime is .NET Core and the file is a DLL, the path extension is changed to `.exe`.

As far as I'm aware, there isn't any way in which you could make the EXE and DLL names different and I've searched the web a bunch. At least we're safe for now but it still feels like a hacky solution.