### PR TITLE
GithubPackageResolver: if "name" is null or empty or whitespace resolve "tag_name" instead

### DIFF
--- a/Onova/Services/GithubPackageResolver.cs
+++ b/Onova/Services/GithubPackageResolver.cs
@@ -75,10 +75,16 @@ namespace Onova.Services
             foreach (var releaseJson in releasesJson.EnumerateArray())
             {
                 // Get release name
-                var releaseName = releaseJson.GetProperty("name").GetString();
+                var releaseTitle = releaseJson.GetProperty("name").GetString();
+
+                // In case property name is null, empty or whitespace then in web version of GitHub it is replaced by a property "tag_name"
+                if (string.IsNullOrWhiteSpace(releaseTitle))
+                {
+                    releaseTitle = releaseJson.GetProperty("tag_name").GetString();
+                }
 
                 // Try to parse version
-                var versionText = Regex.Match(releaseName, "(\\d+\\.\\d+(?:\\.\\d+)?(?:\\.\\d+)?)").Groups[1].Value;
+                var versionText = Regex.Match(releaseTitle, "(\\d+\\.\\d+(?:\\.\\d+)?(?:\\.\\d+)?)").Groups[1].Value;
                 if (!Version.TryParse(versionText, out var version))
                     continue;
 


### PR DESCRIPTION
The way how GitHub release title is shown on the web seems to follow rule:
Set release title to API property `name`. If `name` is null or empty or white space, set release title to API property `tag_name`.

Closes #32.