### PR TITLE
Wait for additional executabes

### DIFF
--- a/Onova.Updater/Internal/FileEx.cs
+++ b/Onova.Updater/Internal/FileEx.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Onova.Updater.Internal
 {
@@ -20,6 +21,16 @@ namespace Onova.Updater.Internal
             {
                 return false;
             }
+        }
+
+        public static async Task<bool> CheckWriteAccessAsync(string filePath)
+        {
+            while (!CheckWriteAccess(filePath))
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            return true;
         }
     }
 }

--- a/Onova.Updater/Program.cs
+++ b/Onova.Updater/Program.cs
@@ -1,4 +1,4 @@
-﻿using Onova.Updater.Internal;
+using Onova.Updater.Internal;
 
 namespace Onova.Updater
 {
@@ -13,8 +13,11 @@ namespace Onova.Updater
             var packageContentDirPath = args[1];
             var restartUpdatee = bool.Parse(args[2]);
             var routedArgs = args[3].FromBase64().GetString();
+            // Base64 encoded semicolon delimited list of paths to executables to wait for
+            // before installing the application
+            var additionalExecutables = args[4].FromBase64().GetString().Split(';');
 
-            using var updater = new Updater(updateeFilePath, packageContentDirPath, restartUpdatee, routedArgs);
+            using var updater = new Updater(updateeFilePath, packageContentDirPath, restartUpdatee, routedArgs, additionalExecutables);
             updater.Run();
         }
     }

--- a/Onova.Updater/Program.cs
+++ b/Onova.Updater/Program.cs
@@ -1,3 +1,4 @@
+﻿using System.Threading.Tasks;
 using Onova.Updater.Internal;
 
 namespace Onova.Updater
@@ -7,7 +8,7 @@ namespace Onova.Updater
 
     public static class Program
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
             var updateeFilePath = args[0];
             var packageContentDirPath = args[1];
@@ -18,7 +19,7 @@ namespace Onova.Updater
             var additionalExecutables = args[4].FromBase64().GetString().Split(';');
 
             using var updater = new Updater(updateeFilePath, packageContentDirPath, restartUpdatee, routedArgs, additionalExecutables);
-            updater.Run();
+            await updater.Run();
         }
     }
 }

--- a/Onova.Updater/Updater.cs
+++ b/Onova.Updater/Updater.cs
@@ -1,9 +1,8 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using Onova.Updater.Internal;
 
@@ -42,7 +41,7 @@ namespace Onova.Updater
             _log.Flush();
         }
 
-        private void RunCore()
+        private async Task RunCore()
         {
             var updateeDirPath = Path.GetDirectoryName(_updateeFilePath);
 
@@ -54,7 +53,7 @@ namespace Onova.Updater
             var executables = new[] { _updateeFilePath }
                 .Concat(_aditionalExecutables.Where(exe => File.Exists(exe)))
                 .Select(exe => FileEx.CheckWriteAccessAsync(exe));
-            Task.WhenAll(executables).Wait();
+            await Task.WhenAll(executables);
 
             // Copy over the package contents
             WriteLog("Copying package contents from storage to updatee's directory...");
@@ -103,7 +102,7 @@ namespace Onova.Updater
             Directory.Delete(_packageContentDirPath, true);
         }
 
-        public void Run()
+        public async Task Run()
         {
             var updaterVersion = Assembly.GetExecutingAssembly().GetName().Version;
 
@@ -117,7 +116,7 @@ namespace Onova.Updater
 
             try
             {
-                RunCore();
+                await RunCore();
             }
             catch (Exception ex)
             {

--- a/Onova.Updater/Updater.cs
+++ b/Onova.Updater/Updater.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -52,7 +52,7 @@ namespace Onova.Updater
             //    Thread.Sleep(100);
 
             var executables = new[] { _updateeFilePath }
-                .Concat(_aditionalExecutables)
+                .Concat(_aditionalExecutables.Where(exe => File.Exists(exe)))
                 .Select(exe => FileEx.CheckWriteAccessAsync(exe));
             Task.WhenAll(executables).Wait();
 

--- a/Onova/Extensions.cs
+++ b/Onova/Extensions.cs
@@ -15,8 +15,8 @@ namespace Onova
         /// The updater can be instructed to also restart the application after it's updated.
         /// If the application is to be restarted, it will receive the same command line arguments as it did initially.
         /// </summary>
-        public static void LaunchUpdater(this IUpdateManager manager, Version version, bool restart = true) =>
-            manager.LaunchUpdater(version, restart, EnvironmentEx.GetCommandLineWithoutExecutable());
+        public static void LaunchUpdater(this IUpdateManager manager, Version version, bool restart = true, string[]? additonalExecutables = null) =>
+            manager.LaunchUpdater(version, restart, EnvironmentEx.GetCommandLineWithoutExecutable(), additonalExecutables);
 
         /// <summary>
         /// Checks for new version and performs an update if available.

--- a/Onova/IUpdateManager.cs
+++ b/Onova/IUpdateManager.cs
@@ -39,8 +39,9 @@ namespace Onova
 
         /// <summary>
         /// Launches an external executable that will apply an update to given version, once this application exits.
-        /// The updater can be instructed to also restart the application after it's updated.
+        /// The updater can be instructed to also restart the application after it's updated. Additional executables
+        /// are relative to the updatee.
         /// </summary>
-        void LaunchUpdater(Version version, bool restart, string restartArguments);
+        void LaunchUpdater(Version version, bool restart, string restartArguments, string[]? additonalExecutables = null);
     }
 }

--- a/Onova/UpdateManager.cs
+++ b/Onova/UpdateManager.cs
@@ -214,7 +214,7 @@ namespace Onova
         }
 
         /// <inheritdoc />
-        public void LaunchUpdater(Version version, bool restart, string restartArguments)
+        public void LaunchUpdater(Version version, bool restart, string restartArguments, string[]? additonalExecutables = null)
         {
             // Ensure that the current state is valid for this operation
             EnsureNotDisposed();
@@ -222,17 +222,23 @@ namespace Onova
             EnsureUpdaterNotLaunched();
             EnsureUpdatePrepared(version);
 
+            var updateeDirPath = Path.GetDirectoryName(Updatee.FilePath);
+
             // Get package content directory path
             var packageContentDirPath = GetPackageContentDirPath(version);
 
             // Get original command line arguments and encode them to avoid issues with quotes
             var routedArgs = restartArguments.GetBytes().ToBase64();
 
+            // get absolute paths to additional executables
+            var addExePaths = (additonalExecutables ?? Array.Empty<string>())
+                .Select(exe => Path.Combine(updateeDirPath!, exe));
+            var addExes = string.Join(";", addExePaths).GetBytes().ToBase64();
+
             // Prepare arguments
-            var updaterArgs = $"\"{Updatee.FilePath}\" \"{packageContentDirPath}\" \"{restart}\" \"{routedArgs}\"";
+            var updaterArgs = $"\"{Updatee.FilePath}\" \"{packageContentDirPath}\" \"{restart}\" \"{routedArgs}\" \"{addExes}\"";
 
             // Decide if updater needs to be elevated
-            var updateeDirPath = Path.GetDirectoryName(Updatee.FilePath);
 
             var updaterNeedsElevation =
                 !string.IsNullOrWhiteSpace(updateeDirPath) &&


### PR DESCRIPTION
In a project where we using Onova to update the application, the program consists of two programs - a client program (possibly multiple instances = updatee) and a little server program that proivides a service of the client instaces).

To update we have to wait for the updatee instances and the server instance to be closed, so that we can overwrite all files.

The implementation creates an optional parameter (string[]? additionalExecutables) in the IUpdateManager.LaunchUpdater. This parameter is passed to the Update as a fourth argument (Base64 encoded semicolon delimited string). In the Update this string is converted to a string array. This string array is then used in the RunCore method to wait for the specified files (but only if the file exists). All waiting is implemented asynchronously, therefore the signatures of the Main method and the methods on the path to the RunCore method have been converted to "async Task" as return type.

The actual check is still performed by the FileEx.CheckWriteAccess method, however it is wapped into a CheckWriteAccessAsync method that perfoms the loop and the delay. The delay is implemented by Task.Delay as conserves more system resources.

I tried to write a test for this, but due to time constraints and the necessary plumbing I could not complete it. However, I tested the code in an actual application and it performed as expected.

The paths to the additional executable have to be relative to the updatee - the absolute path is calculated by conatenating the updatee directory and the specified relative path.